### PR TITLE
(apns_connection): Allow passing of TLS options

### DIFF
--- a/src/apns_connection.erl
+++ b/src/apns_connection.erl
@@ -226,7 +226,7 @@ open_connection(internal, _, #{connection := Connection} = StateData) ->
 open_origin(internal, _, #{connection := Connection} = StateData) ->
   Host = host(Connection),
   Port = port(Connection),
-  TransportOpts = transport_opts(Connection),
+  #{tls_opts := TransportOpts } = Connection,
   {next_state, open_common, StateData,
     {next_event, internal, { Host
                            , Port


### PR DESCRIPTION
This change adds a new property: `tls_opts` to the Connection paramaters passed to `apns4erl`. The value of this new property is the same as those accepted by `:ssl.connect` as shown here: https://ninenines.eu/docs/en/gun/1.3/manual/gun.open/